### PR TITLE
add test case of PlutoStaticHTML

### DIFF
--- a/_css/franklin.css
+++ b/_css/franklin.css
@@ -399,6 +399,15 @@ code {
     color: rgb(51, 131, 231);
 }
 
+.code-output{
+    border: 1px dashed #dbdbdb;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' class='code-output-label' height='20px' width='40px'><text x='0' y='15' fill='grey' font-size='0.8em'>output</text></svg>");
+    background-repeat: no-repeat;
+    background-position: right 5px top 5px;
+}
+.code-output-label {
+    font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+}
 /* ==================================================================
     BOXES
 ================================================================== */

--- a/tutorials/MortalityTablesDataFrame2.md
+++ b/tutorials/MortalityTablesDataFrame2.md
@@ -1,0 +1,3 @@
+# DataFrames and *MortalityTables.jl*
+
+\pluto{MortalityTablesDataFrame}

--- a/utils.jl
+++ b/utils.jl
@@ -14,3 +14,60 @@ function lx_baz(com, _)
   # do whatever you want here
   return uppercase(brace_content)
 end
+
+
+"""
+    lx_pluto(com, _)
+
+Embed a Pluto notebook via:
+https://github.com/rikhuijzer/PlutoStaticHTML.jl
+"""
+function lx_pluto(com, _)
+    file = string(Franklin.content(com.braces[1]))::String
+    notebook_path = joinpath("notebooks", "$file.jl")
+    log_path = joinpath("notebooks", "$file.log")
+
+    return """
+        ```julia:pluto
+        # hideall
+
+        using PlutoStaticHTML: notebook2html
+
+        path = "$notebook_path"
+        log_path = "$log_path"
+        @assert isfile(path)
+        @info "→ evaluating Pluto notebook at (\$path)"
+        html = open(log_path, "w") do io
+            redirect_stdout(io) do
+                html = notebook2html(path)
+                return html
+            end
+        end
+        println("~~~\n\$html\n~~~\n")
+        ```
+        \\textoutput{pluto}
+        """
+end
+
+"""
+    lx_readhtml(com, _)
+
+Embed a Pluto notebook via:
+https://github.com/rikhuijzer/PlutoStaticHTML.jl
+"""
+function lx_readhtml(com, _)
+    file = string(Franklin.content(com.braces[1]))::String
+    dir = joinpath("posts", "notebooks")
+    filename = "$(file).jl"
+
+    return """
+        ```julia:pluto
+        # hideall
+
+        filename = "$filename"
+        html = read(filename, String)
+        println("~~~\n\$html\n~~~\n")
+        ```
+        \\textoutput{pluto}
+        """
+end


### PR DESCRIPTION
This seems like it will be a great solution to include the Pluto notebook contents into the site. A few things I'd still like to do before implementing:

- [ ] add other notebooks
- [ ] drop `MortalityTablesDataFrame2.md` where the original sits
- [ ] symlink(?) to/from Learn repository (that way the ugly website directory doesn't become the go-to for notebook storage)
- [ ] implement parallel CI: https://github.com/rikhuijzer/PlutoStaticHTML.jl/issues/41
- [ ] add ref to notebook: https://github.com/rikhuijzer/PlutoStaticHTML.jl/issues/25
- [ ] Make `code-output` blocks prettier