### PR TITLE
Fix correctness and conceptual issues across site pages

### DIFF
--- a/assets/themes/cassette_futurism.jl
+++ b/assets/themes/cassette_futurism.jl
@@ -69,6 +69,7 @@ function cassette_futurism_theme(; font::String = "JuliaMono")
             patchcolor = CASSETTE_PALETTE,
         ),
         linewidth = 1.6,
+        figure_padding = 18,
 
         Axis = (
             backgroundcolor      = CF_PAPER,
@@ -82,10 +83,10 @@ function cassette_futurism_theme(; font::String = "JuliaMono")
             yminorticksvisible   = true,
             xticksvisible        = true,
             yticksvisible        = true,
-            xtickalign           = 1.0,        # outward — draftsman style
-            ytickalign           = 1.0,
-            xminortickalign      = 1.0,
-            yminortickalign      = 1.0,
+            xtickalign           = 0.0,        # outward — draftsman style (0 = out, 1 = in)
+            ytickalign           = 0.0,
+            xminortickalign      = 0.0,
+            yminortickalign      = 0.0,
             xtickwidth           = 0.9,
             ytickwidth           = 0.9,
             xticksize            = 5,
@@ -139,7 +140,7 @@ function cassette_futurism_theme(; font::String = "JuliaMono")
         Colorbar = (
             spinewidth      = 1.0,
             tickcolor       = CF_INK,
-            tickalign       = 1.0,
+            tickalign       = 0.0,
             ticklabelcolor  = CF_INK,
             ticklabelfont   = font,
             labelcolor      = CF_INK,
@@ -153,10 +154,5 @@ function cassette_futurism_theme(; font::String = "JuliaMono")
         Density  = (strokewidth = 1.6, strokecolor = CF_INK),
         Heatmap  = (colormap = :lajolla,),
         Contour  = (color = CF_INK, linewidth = 1.0),
-
-        Figure = (
-            backgroundcolor = CF_PAPER,
-            figure_padding  = 18,
-        ),
     )
 end

--- a/benchmarks.qmd
+++ b/benchmarks.qmd
@@ -107,7 +107,7 @@ All of the benchmarked code can be found in the [JuliaActuary Learn repository](
 
 ## IRRs
 
-**Task:** determine the IRR for a series of cashflows 701 elements long (e.g. monthly cashflows for 60 years).
+**Task:** determine the IRR for a series of cashflows 701 elements long (roughly 58 years of monthly cashflows).
 
 ### Benchmarks
 
@@ -127,7 +127,7 @@ Times are in nanoseconds:
 
 ### Discussion
 
-The ActuaryUtilities implementation is over 100,000 times faster than `numpy_financial`, and 91 to 722 times faster than the `better` Python package. The [ActuaryUtilities.jl](/#actuaryutilitiesjl) implementation is also more flexible, as it can be given an argument with timepoints, similar to Excel's `XIRR`.
+The ActuaryUtilities implementation is over 100,000 times faster than `numpy_financial`, and 91 to 722 times faster than the `better` Python package. The [ActuaryUtilities.jl](/packages.html#actuaryutilities.jl) implementation is also more flexible, as it can be given an argument with timepoints, similar to Excel's `XIRR`.
 
 Excel was used to attempt a benchmark, but the `IRR` formula returned a `#DIV/0!` error.
 
@@ -154,7 +154,7 @@ Times are in nanoseconds:
 ┌──────────┬─────────┬─────────────┬───────────────┐
 │ Language │  Median │        Mean │ Relative Mean │
 ├──────────┼─────────┼─────────────┼───────────────┤
-│   Python │ missing │    817000.0 │       19926.0 │
+│   Python │ missing │    817000.0 │       19639.4 │
 │        R │  3649.0 │      3855.2 │          92.7 │
 │    Julia │    41.0 │        41.6 │           1.0 │
 └──────────┴─────────┴─────────────┴───────────────┘
@@ -180,6 +180,6 @@ All of the benchmarked code can be found in the [JuliaActuary Learn repository](
 
 ## Footnotes
 
-[^1] If benchmarking memoization, it's essentially benchmarking how long it takes to perform hashing in a language. While interesting, especially in the context of [incremental computing](https://scattered-thoughts.net/writing/an-opinionated-map-of-incremental-and-streaming-systems), it's not the core issue at hand. Incremental computing libraries exist for all of the modern languages discussed here.
+[^1]: If benchmarking memoization, it's essentially benchmarking how long it takes to perform hashing in a language. While interesting, especially in the context of [incremental computing](https://scattered-thoughts.net/writing/an-opinionated-map-of-incremental-and-streaming-systems), it's not the core issue at hand. Incremental computing libraries exist for all of the modern languages discussed here.
 
-[^2] Note that not all languages have both a mean and median result in their benchmarking libraries. Mean is a better representation for a garbage-collected modern language, because sometimes the computation just takes longer than the median result. Where the mean is not available in the graph below, median is substituted.
+[^2]: Note that not all languages have both a mean and median result in their benchmarking libraries. Mean is a better representation for a garbage-collected modern language, because sometimes the computation just takes longer than the median result. Where one of the two statistics is not reported, the other is shown.

--- a/index.qmd
+++ b/index.qmd
@@ -39,7 +39,7 @@ Clean, readable syntax, comprehensive documentation, and seamless integration wi
 
 **JuliaActuary** is an ecosystem of packages that makes Julia the easiest language to get started for actuarial workflows.
 
-**Julia** is [an ideal language for Actuaries](/blog/julia-actuaries/) and other financial professionals.
+**Julia** is [an ideal language for Actuaries](/posts/julia-for-actuaries/) and other financial professionals.
 
 
 It is free, open-source software and you can [join the development on Github](https://github.com/JuliaActuary/).
@@ -98,7 +98,7 @@ julia> quotes     = ZCBYield.(rates,maturities)
 julia> rf_curve = fit(Spline.Cubic(), quotes, Fit.Bootstrap())
 
 
-               ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Yield Curve (FinanceModels.YieldCurve)⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+               ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Yield Curve (FinanceModels.Yield.Spline)⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
                ┌────────────────────────────────────────────────────────────┐
            0.4 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ Zero rates
                │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
@@ -178,12 +178,13 @@ life = SingleLife(                       # The life underlying the risk
 
 yield = Yield.Constant(0.05)            # Using a flat 5% interest rate
 
-ins = Insurance(life, yield)             # alternate way to construct
+lc = LifeContingency(life, yield)        # combine the life with the yield
+ins = Insurance(lc)                      # alternate way to construct: Insurance(life, yield)
 
 # Summary Scalars
 present_value(ins)                       # The actuarial present value
-premium_net(lc)                          # Net whole life premium 
-V(lc,5)                                  # Net premium reserve for whole life insurance at time 5
+premium_net(lc)                          # Net whole life premium
+LifeContingencies.V(lc,5)                # Net premium reserve for whole life insurance at time 5
 ```
 
 ```{=html}
@@ -210,20 +211,20 @@ V(lc,5)                                  # Net premium reserve for whole life in
 
 These packages are available for use in your project. See more on the [Packages page](/packages.qmd).
 
-[`MortalityTables.jl`](/packages/#mortalitytablesjl)
+[`MortalityTables.jl`](/packages.html#mortalitytables.jl)
   - Easily work with standard [mort.SOA.org](https://mort.soa.org/) tables and parametric models with common survival calculations.
 
-[`LifeContingencies.jl`](/packages/#lifecontingenciesjl)
+[`LifeContingencies.jl`](/packages.html#lifecontingencies.jl)
 - Insurance, annuity, premium, and reserve maths.
 
-[`ActuaryUtilities.jl`](/packages/#actuaryutilitiesjl)
+[`ActuaryUtilities.jl`](/packages.html#actuaryutilities.jl)
 - Robust and fast calculations for `internal_rate_of_return`, `duration`, `convexity`, `present_value`, `breakeven`, and AD-based key rate `sensitivities`.
 
-[`FinanceModels.jl`](/packages/#FinanceModelsjl)
+[`FinanceModels.jl`](/packages.html#financemodels.jl)
 - Composable contracts, models, and functions for financial instruments — including stochastic short-rate models and Monte Carlo simulation.
 
-[`ExperienceAnalysis.jl`](/packages/#experienceanalysisjl)
+[`ExperienceAnalysis.jl`](/packages.html#experienceanalysis.jl)
 - Meeting your exposure calculation needs.
 
-[`EconomicScenarioGenerators.jl`](/packages/#economicscenariogeneratorsjl)
+[`EconomicScenarioGenerators.jl`](/packages.html#economicscenariogenerators.jl)
 - Easy-to-use scenario generation that's FinanceModels.jl compatible.

--- a/packages.qmd
+++ b/packages.qmd
@@ -301,7 +301,7 @@ Other types of life contingent benefits:
 
 ```julia
 Insurance(lc,10)                 # 10 year term insurance
-AnnuityImmediate(lc)               # Whole life annuity due
+AnnuityImmediate(lc)               # Whole life annuity immediate
 AnnuityDue(lc)                     # Whole life annuity due
 ä(lc)                              # Shortform notation
 ä(lc, 5)                           # 5 year annuity due
@@ -346,17 +346,17 @@ q_rate = ZCBYield([0.01,0.02,0.03]);
 q_spread = ZCBYield([0.01,0.01,0.01]);
 
 # bootstrap a linear spline yield model
-model_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());⠀           
+model_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());
 model_spread = fit(Spline.Linear(),q_spread,Fit.Bootstrap());
 
 # the zero rate is the combination of the two underlying rates
-zero(m_spread + m_rate,1) # 0.02 annual effective rate 
+zero(model_spread + model_rate,1) # ≈ 0.02
 
-# the discount is the same as if we added the underlying zero rates
-discount(m_spread + m_rate,0,3) ≈ discount(0.01 + 0.03,3)   # true
+# combining models composes the discount factors multiplicatively
+discount(model_spread + model_rate,0,3) ≈ discount(model_spread,0,3) * discount(model_rate,0,3)   # true
 
 # compute the present value of a contract (a cashflow of 10 at time 3)
-present_value(m_rate,Cashflow(10,3)) # 9.15...
+present_value(model_rate,Cashflow(10,3)) # 9.15...
 ```
 
 ### Overview of FinanceModels
@@ -423,7 +423,7 @@ The models can be used to compute various rates of interest:
 
 - `discount(curve,from,to)` or `discount(curve,to)` gives the discount factor
 - `accumulation(curve,from,to)` or `accumulation(curve,to)` gives the accumulation factor
-- `zero(curve,time)` or `zero(curve,time,Frequency)` gives the zero-coupon spot rate for the given time.
+- `zero(curve,time)` gives the zero-coupon spot rate for the given time (returned as a `Continuous` `Rate`).
 - `forward(curve,from,to)` gives the zero rate between the two given times
 - `par(curve,time;frequency=2)` gives the coupon-paying par equivalent rate for the given time.
 
@@ -477,14 +477,14 @@ However, `Projection`s allow one to combine three elements which can be extended
        Model                                                               Method
           |                                                                   |
   	|------------|                                                     |---------------|
-fit(Spline.Cubic(), CMTYield.([0.04,0.05,0.055,0.06,0055],[1,2,3,4,5]), Fit.Bootstrap())
+fit(Spline.Cubic(), CMTYield.([0.04,0.05,0.055,0.06,0.065],[1,2,3,4,5]), Fit.Bootstrap())
                     |-------------------------------------------------|
                                               |
                                               Quotes
 ```
 
  - **Model** could be `Spline.Linear()`, `Yield.NelsonSiegelSvensson()`, `Equity.BlackScholesMerton(...)`, etc.
- - **Quote** could be `CMTYield`s, `ParYield`s, `Option.Eurocall`, etc.
+ - **Quote** could be `CMTYield`s, `ParYield`s, `Option.EuroCall`, etc.
  - **Method** could be `Fit.Loss(x->x^2)`, `Fit.Loss(x->abs(x))`, `Fit.Bootstrap()`, etc.
 
 
@@ -607,9 +607,9 @@ df.exposure_fraction =
 
 Where `period` is a [Period Type from the Dates standard library](https://docs.julialang.org/en/v1/stdlib/Dates/#Period-Types).
 
-Calculate exposures with `exposures(basis,from,to,continue_exposure)`. 
+Calculate exposures with `exposure(basis, from, to, continued_exposure; study_start, study_end)`.
 
-- `continue_exposures` indicates whether the exposure should be extended through the full exposure period rather than terminate at the `to` date.
+- `continued_exposure` indicates whether the exposure should be extended through the full exposure period rather than terminate at the `to` date.
 
 [ExperienceAnalysis package on GitHub 🡭](https://github.com/JuliaActuary/ExperienceAnalysis.jl)
 
@@ -629,7 +629,7 @@ Calculate exposures with `exposures(basis,from,to,continue_exposure)`.
 #### Interest Rate Models
 
 - `Vasicek`
-- `CoxIngersolRoss`
+- `CoxIngersollRoss`
 - `HullWhite`
 
 #### EquityModels
@@ -673,7 +673,7 @@ YieldCurve(s)
 will produce a yield curve object:
 
 ```julia-repl
-              ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Yield Curve (FinanceModels.BootstrapCurve)⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀           
+              ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Yield Curve (FinanceModels.Yield.Spline)⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
               ┌────────────────────────────────────────────────────────────┐           
          0.03 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⠤⠤⠔⠒⠉⠉⠒⠒⠒⠒⠒⠤⣄⣀│ Zero rates
               │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⠤⠒⠒⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│           

--- a/posts/academy-generator-rates/index.qmd
+++ b/posts/academy-generator-rates/index.qmd
@@ -13,7 +13,7 @@ Scroll down below the sample video to see how to run it.
  </video>
 ```
 
-The recording above shows a [Pluto.jl](https://github.com/fonsp/Pluto.jl) notebook manipulating the long term mean reversion parameter for the Nelson-Siegel functional interest rate model, based on the American Academy of Actuaries' (AAA) [Economic Scenario Generator](https://www.actuary.org/content/economic-scenario-generators) (ESG).
+The recording above shows a [Pluto.jl](https://github.com/fonsp/Pluto.jl) notebook manipulating the long-rate mean reversion parameter of the stochastic interest rate process (with the full curve interpolated via a Nelson-Siegel functional form), based on the American Academy of Actuaries' (AAA) [Economic Scenario Generator](https://www.actuary.org/content/economic-scenario-generators) (ESG).
 
 ## Instructions to Run
 
@@ -37,4 +37,4 @@ https://raw.githubusercontent.com/JuliaActuary/Learn/master/AAA_ESG.jl
 
 ## See also
 
-[Replicating the AAA equtity generator](/examples/academy-generator/)
+[Replicating the AAA equity generator](/posts/academy-generator/)

--- a/posts/academy-generator/index.qmd
+++ b/posts/academy-generator/index.qmd
@@ -179,4 +179,4 @@ end
 
 ## See also
 
-[Interactive AAA Economic Scenario Generator](/examples/academy-generator-rates/)
+[Interactive AAA Economic Scenario Generator](/posts/academy-generator-rates/)

--- a/posts/autodiff_ALM/index.qmd
+++ b/posts/autodiff_ALM/index.qmd
@@ -260,14 +260,14 @@ The first element of `vgh_liab` is the value of the liability portfolio using th
 vgh_liab[1]
 ```
 
-The second element of `vgh_liab` is the partial derivative with respect to each of the inputs (here, just the `zeros` rates that dictate the curve). The sum of the partials is the effective duration of the liabilities. 
+The second element of `vgh_liab` is the partial derivative with respect to each of the inputs (here, just the `zeros` rates that dictate the curve). The sum of the partials is the (dollar) sensitivity of the liabilities to a parallel shift in rates — a dollar duration, which becomes the effective duration once divided by the value (shown below).
 
 ```{julia}
 @show sum(vgh_liab[2])
 vgh_liab[2]
 ```
 
-This is the sensitivity relative to a full unit change in rates (e.g. `1.0`). So if we wanted to estimate the dollar impact of a 50bps change, we would take `0.005` times the gradient/hessian. Also note these are 'dollar durations' but we could divide by the price to get `effective` or percentage durations:
+This is the sensitivity relative to a full unit change in rates (e.g. `1.0`). So if we wanted to estimate the dollar impact of a 50bps change, we would take `0.005` times the gradient (and for the second-order refinement, add `½ × 0.005²` times the hessian). Also note these are 'dollar durations' but we could divide by the price to get `effective` or percentage durations:
 
 ```{julia}
 -sum(vgh_liab[2]) / vgh_liab[1]
@@ -292,7 +292,7 @@ let
 end
 ```
 
-Due to the steepness of the surrender function, the policy exiting sooner, on average, results in a higher change in value than if the policy was not sensitive to the change in rates. The increase in value from earlier cashflows outweighs the greater discount rate.
+Due to the steepness of the surrender function, a rise in rates causes the policy to exit sooner on average, shortening the liability and partially offsetting the discounting effect. The dynamic sensitivity is therefore smaller in magnitude than the static sensitivity, which ignores the interest-sensitive behavior.
 
 The third element of `vgh_liab` is the Hessian matrix, containing all second partial derivatives with respect to the yield curve inputs:
 
@@ -386,7 +386,7 @@ function optimize_portfolio(assets, vgh_assets, liabs, vgh_liabs, constraints)
 
     # Gradient component (krd) constraints
     for j in 1:length(vgh_liabs[2])
-        gradient_sum = sum(w[i] * vgh_assets[i][2][j] for i in 1:n) - sum(vgh_liabs[2][j])
+        gradient_sum = sum(w[i] * vgh_assets[i][2][j] for i in 1:n) + vgh_liabs[2][j]
 
         @constraint(model, gradient_sum >= constraints[:krd][:lower])
         @constraint(model, gradient_sum <= constraints[:krd][:upper])
@@ -394,8 +394,8 @@ function optimize_portfolio(assets, vgh_assets, liabs, vgh_liabs, constraints)
 
     # total duration constraint 
     duration_gap = sum(w[i] * sum(vgh_assets[i][2]) for i in 1:n) + sum(vgh_liabs[2])
-    @constraint(model, duration_gap <= constraints[:krd][:upper])
-    @constraint(model, duration_gap >= constraints[:krd][:lower])
+    @constraint(model, duration_gap <= constraints[:duration][:upper])
+    @constraint(model, duration_gap >= constraints[:duration][:lower])
 
     # Solve
     optimize!(model)

--- a/posts/bayes-vs-limited-fluctuation/index.qmd
+++ b/posts/bayes-vs-limited-fluctuation/index.qmd
@@ -55,7 +55,7 @@ $$
 \text{Credibility-Weighted Rate} = Z × \text{Observed Rate} + (1 – Z) × \text{Prior Rate}
 $$
 
-With probability equal to $LC_p$ that the Observed Rate does not differ from the true rate by more than $LC_r$.
+With probability equal to $LC_p$ that the Observed Rate does not differ from the true rate by more than $LC_r$ *of the true rate* (i.e. a ±5% relative margin, not an absolute one).
 
 ```{julia}
 LC_p = 0.9
@@ -70,9 +70,9 @@ $$
 LC_full_credibility = round(Int, (quantile(Normal(), 1 - (1 - LC_p) / 2) / LC_r)^2)
 ```
 
-Using the inputs above, we have a z-score corresponding to `{julia} LC_p` of `{julia} quantile(Normal(),1-(1-LC_p)/2)`, so: ( `{julia} quantile(Normal(),1-(1-LC_p)/2)` ÷ `{julia} LC_r`)² ≈ `{julia} LC_full_credibility`. """
+Using the inputs above, we have a z-score corresponding to `{julia} LC_p` of `{julia} quantile(Normal(),1-(1-LC_p)/2)`, so: ( `{julia} quantile(Normal(),1-(1-LC_p)/2)` ÷ `{julia} LC_r`)² ≈ `{julia} LC_full_credibility`.
 
-[Atkinson](https://www.soa.org/globalassets/assets/files/resources/tables-calcs-tools/credibility-methods-life-health-pensions.pdf) goes on to nicely summarize the square root method which assigns full credibility, $$Z = 1$$, when the number of actual claims equals or exceeds the full credibility threshold of \$LC_full_credibility claims.
+[Atkinson](https://www.soa.org/globalassets/assets/files/resources/tables-calcs-tools/credibility-methods-life-health-pensions.pdf) goes on to nicely summarize the square root method which assigns full credibility, $$Z = 1$$, when the number of actual claims equals or exceeds the full credibility threshold of `{julia} LC_full_credibility` claims.
 
 When the number of claims is less than full credibility:
 
@@ -88,7 +88,7 @@ $$
     -   Results in a single point estimate with only approximate measure of estimate uncertainty
 -   Relies on a number of assumptions/constraints:
     -   That aggregated claims can be approximated by a normal distribution
-    -   The thresholds of \$LC_p and \$LC_r are arbitrary (e.g. all of the same arguments against p-value thresholds can apply to this approach) """
+    -   The thresholds of `LC_p` and `LC_r` are arbitrary (e.g. all of the same arguments against p-value thresholds can apply to this approach)
 
 ## Bayesian Approach
 
@@ -147,7 +147,7 @@ A complete overview of modern Bayesian models is beyond the scope of this notebo
     -   `σ \sim Exponential(0.25)` says that we expect the standard devation of an individual group to be positive, but not super wide.
     -   `μ_i \sim Normal(μ,σ)` is the actual prior for each group's rate of claim and is informed by the above hyperparameters.
 -   `@model` is a Turing.jl macro which enables interpreting the nice `~` syntax, which makes the Julia code look very similar to the traditional mathematical notation.
--   Note the use of broadcasting with the dot syntax (e.g. the `.` in `.~`). This tells Julia to vectorize and fuse the computation.
+-   Note the use of broadcasting with the dot syntax (e.g. the `.` in `Poisson.(...)`). This tells Julia to vectorize the computation, creating one distribution per group, and `product_distribution` combines them into a joint distribution for the vector of observations.
     -   `data.claims ~ product_distribution(Poisson.(data.n .* logistic.(μ_i)))` means "each value in `data.claims` is a random outcome (`~`) distributed accroding to a corresponding Poisson distribution with `\lambda =n \times \text{logistic}(\mu_i)` where `text{logistic}(\mu_i)` is the average claims rate for each group.
 
 ```{julia}
@@ -166,7 +166,7 @@ A complete overview of modern Bayesian models is beyond the scope of this notebo
 end
 ```
 
-Here's what the prior distribution of claims looks like... and peeking ahead to what the posterior for a single group of claims looks like. See how even though our posterior was very wide (favoring small claims rates), it was dominated by the data to create a very narrow posterior average claims rate.
+Here's what the prior distribution of claims looks like... and peeking ahead to what the posterior for a single group of claims looks like. See how even though our prior was very wide (favoring small claims rates), it was dominated by the data to create a very narrow posterior average claims rate.
 
 The model is combined with the data and [Turing.jl](https://turing.ml/stable/) is used to computationally arrive at the posterior distribution for the parameters in the statistical model, $\mu$, $\mu_i$, and $\sigma$.
 
@@ -271,7 +271,7 @@ Here we compare four predictive models:
 
 ### Bayesian approach has lower error
 
-Looking at the accumulated absolute error, the bayesian approach has about 16% lower error than the Limited Fluctuation approaches.
+Looking at the accumulated absolute error (plotted below), the bayesian approach has meaningfully lower total error than the Limited Fluctuation approaches.
 
 ### Total Actual to Expected
 
@@ -422,4 +422,4 @@ With limited, real-world data drawing conclusions is a little bit messy because 
 
 -   The Bayesian approach partially pools the data: it's an approach in-between assuming each group is independent from the rest and assuming that a single rate applies to all exposures.
 -   The partial pooling limits over-fitting, which happens with the naive approach. Our Bayesian approach is somewhat skeptical of groups with low observation counts that stand out from the rest. But it also doesn't forgoe useful data, as it learns from even low exposures according to what's consistent with probability theory (Baye's rule).
--   The naive approach is pretty close to the textbook definition of over-fitting. The LF approaches appear to be under-fitting group-level as there are only \$(sum(claims_summary_posterior.LF_Z_train .\>= .9999)) groups with "full credibility" (`Z=1`), even though there are groups with less than "full credibility" with over 100,000 observations in the training set.
+-   The naive approach is pretty close to the textbook definition of over-fitting. The LF approaches appear to be under-fitting group-level as there are only `{julia} sum(claims_summary_posterior.LF_Z_train.>=0.9999)` groups with "full credibility" (`Z=1`), even though there are groups with less than "full credibility" with over 100,000 observations in the training set.

--- a/posts/bayesian-claims-demo/index.qmd
+++ b/posts/bayesian-claims-demo/index.qmd
@@ -70,10 +70,10 @@ function generate_data_individual(tbl, issue_age=rand(50:55), inforce_years=rand
     # we observe the assigned risklevel, but not risk_factor
     risk_factors = [0.7, 1.0, 1.5]
     rf = risk_factors[risklevel]
-    deaths = rand(inforce_years) .< (tbl.select[issue_age][issue_age.+inforce_years.-1] .* rf)
+    deaths = rand(inforce_years) .< (tbl.select[issue_age][issue_age .+ (1:inforce_years) .- 1] .* rf)
 
     endpoint = if sum(deaths) == 0
-        last(inforce_years)
+        inforce_years
     else
         findfirst(deaths)
     end
@@ -135,7 +135,7 @@ We use a No-U-Turn-Sampler (NUTS) technique to sample multiple chains at once:
 
 ```{julia}
 #| column: page-inset
-chain = MCMCChains.Chains(sample(m1, NUTS(), 1000))
+chain = MCMCChains.Chains(sample(m1, NUTS(), MCMCThreads(), 1000, num_chains))
 
 chainplot(chain)
 ```
@@ -366,8 +366,6 @@ chain4 = MCMCChains.Chains(sample(m4, NUTS(), 1000))
 summarize(chain4)
 ```
 
-PRECIS(DataFrame(chain4))
-
 ```{julia}
 risk_factors4 = [mean(chain4[Symbol("a[$f]")]) for f in 1:3]
 ```
@@ -389,7 +387,7 @@ let data = data2
     for r in 1:3, i in 1:n
         s = sample(chain4, 1)
         a = only(s[Symbol("a[$r]")])
-        b = only(s[:b]); k = only(s[:k]); c = 0
+        b = only(s[:b]); k = only(s[:k]); c = only(s[:c])
         m = MortalityTables.MakehamBeard(; a, b, c, k)
         lines!(ax, ages, age -> MortalityTables.hazard(m, age);
             color=(risk_colors[r], 0.12), linewidth=0.8,

--- a/posts/bayesian-intro/index.qmd
+++ b/posts/bayesian-intro/index.qmd
@@ -80,7 +80,7 @@ In fact, the "objective" approach to null hypothesis testing is so prone to abus
 
 Further, when assigning a prior assumption to a random variable, there are mathematically most conservative choices to pull from. These are called Maximum Entropy Distributions (MED) and it can be shown that for certain minimal constraints these are the information-theoretic least informative choices. Least informative means that the prior will have the least influence on the resulting posterior distribution. 
 
-For example, if all you know is that the mean of a random process is positive, then the Exponential Distribution is your MED. If you know that a mean and variance must exist for the process, then the Normal distribution is your MED. If you know nothing at all, you can use a Uniform distribution for the possible values.
+For example, if all you know is that a random process is positive-valued with a given mean, then the Exponential Distribution is your MED. If you know the mean and variance of a process on the real line, then the Normal distribution is your MED. If all you know is that the values fall within a bounded range, the Uniform distribution over that range is your MED.
 
 ## Bayesian Versus Machine Learning
 

--- a/posts/cashflow-interactive/index.qmd
+++ b/posts/cashflow-interactive/index.qmd
@@ -8,7 +8,7 @@ Scroll down below the sample video to see how to run it.
 ![](demo.gif)
 
 
-The recording above shows a [Pluto.jl](https://github.com/fonsp/Pluto.jl) notebook demonstrating some of the basic cashflow-oriented features in `ActuaryUtilities.jl` and `Yields.jl`.
+The recording above shows a [Pluto.jl](https://github.com/fonsp/Pluto.jl) notebook demonstrating some of the basic cashflow-oriented features in `ActuaryUtilities.jl` and `FinanceModels.jl`.
 
 ## Instructions to Run
 

--- a/posts/cassette-futurism-theme/index.qmd
+++ b/posts/cassette-futurism-theme/index.qmd
@@ -60,7 +60,8 @@ let
         xlabel = "t / s", ylabel = "amplitude",
     )
     for (i, ζ) in enumerate((0.05, 0.12, 0.22, 0.40))
-        lines!(ax, t, exp.(-ζ .* t) .* cos.(t); label = "ζ = $ζ")
+        # unit natural frequency: x(t) = e^{-ζt}·cos(√(1-ζ²)·t)
+        lines!(ax, t, exp.(-ζ .* t) .* cos.(sqrt(1 - ζ^2) .* t); label = "ζ = $ζ")
     end
     axislegend(ax, position = :rt, framevisible = true)
     fig
@@ -97,10 +98,10 @@ end
 ```{julia}
 let
     cats   = ["LEM", "CSM", "S-IVB", "S-II", "S-IC"]
-    values = [4.7, 6.3, 10.1, 14.8, 22.4]
+    values = [4.3, 11.9, 13.5, 36.0, 130.0]  # approximate dry masses
     fig = Figure(size = (720, 380))
     ax = Axis(fig[1, 1];
-        title = "FIG. 03 — STAGE MASS / 10³ kg",
+        title = "FIG. 03 — STAGE DRY MASS / 10³ kg (APPROX.)",
         xticks = (1:length(cats), cats),
         ylabel = "mass",
     )

--- a/posts/exposures-example/index.qmd
+++ b/posts/exposures-example/index.qmd
@@ -10,7 +10,7 @@ Pkg.activate(".")
 Pkg.instantiate()
 ```
 
-In this tutorial, we will walk through how to calculate exposures using the [ExperienceAnalysis.jl package](/packages/#lifecontingenciesjl).
+In this tutorial, we will walk through how to calculate exposures using the [ExperienceAnalysis.jl package](/packages.html#experienceanalysis.jl).
 
 In summary, the package will help calculate the exposure periods given parameters about the kind of period and timepoints under consideration. This will return an array of tuples with a `from` and `to` date:
 
@@ -33,9 +33,9 @@ exposure(basis, issue, termination)
 
 Where `period` is a [Period Type from the Dates standard library](https://docs.julialang.org/en/v1/stdlib/Dates/#Period-Types).
 
-Calculate exposures with `exposures(basis,from,to,continue_exposure)`. 
+Calculate exposures with `exposure(basis, from, to, continued_exposure; study_start, study_end)`.
 
-- `continue_exposures` indicates whether the exposure should be extended through the full exposure period rather than terminate at the `to` date.
+- `continued_exposure` indicates whether the exposure should be extended through the full exposure period rather than terminate at the `to` date.
 
 ## Full Example
 
@@ -84,7 +84,8 @@ This can be extended to calculate the decimal fraction of the year under differe
 ```{julia}
 using DayCounts
 
-df.exposure_fraction = map(e -> yearfrac(e.from, e.to, DayCounts.Actual360()), df.exposure)
+# note: the `to` date is inclusive, so we add a day when computing the fraction
+df.exposure_fraction = map(e -> yearfrac(e.from, e.to + Day(1), DayCounts.Thirty360()), df.exposure)
 df[:, [:exposure, :exposure_fraction]]
 ```
 

--- a/posts/finance-models-announcement/index.qmd
+++ b/posts/finance-models-announcement/index.qmd
@@ -21,16 +21,16 @@ This blog post describes the conceptual overview and motivation for the change.
 
 ## 1. `Cashflow` - a fundamental financial type
 
-Say you wanted to model a contract that paid quarterly payments, and those payments occurred starting 15 days from the valuation date (first payment time = 15/365 = 0.057)
+Say you wanted to model a contract that paid quarterly payments, and those payments occurred starting 15 days from the valuation date (first payment time = 15/365 ≈ 0.041)
 
 Previously, you had two options:
 
 1. Choose a discrete timestep to model (e.g. monthly, quarterly, annual) and then lump the cashflows into those timesteps. E.g. with monthly timesteps  of a unit payment of our contract, it might look like: `[1,0,0,1,0,0...]`
-2. Keep track of two vectors: one for the payment and one for the times. In this case, that might look like: `cfs = [1,1,...]; `times = `[0.057, 0.307...]`
+2. Keep track of two vectors: one for the payment and one for the times. In this case, that might look like: `cfs = [1,1,...]; `times = `[0.041, 0.291...]`
 
 The former has inaccuracies due to the simplified timing and logical complication related to mapping the contracts natural periodicity into an arbitrary modeling choice. The latter becomes unwieldy and fails to take advantage of Julia's type system. 
 
-The new solution: `Cashflow`s. Our example above would become: `[Cashflow(1,0.057), Cashflow(1,0.307),...]`
+The new solution: `Cashflow`s. Our example above would become: `[Cashflow(1,0.041), Cashflow(1,0.291),...]`
 
 ## 2. **Contracts** - A composable way to represent financial instruments
 
@@ -57,7 +57,7 @@ A contract is anything that creates a vector of `Cashflow`s when `collect`ed. Fo
 using FinanceModels,FinanceCore
 
 # Transducers is used to provide a more powerful, composable way to construct collections than the basic iteration interface
-using Transducers: __foldl__, @next, complete
+using Transducers: Transducers, __foldl__, @next, complete
 
 """
 A bond which pays down its par (one unit) in equal payments. 
@@ -190,14 +190,14 @@ julia> map(q -> pv(m,q.instrument),quotes)
        Model                                                               Method
           |                                                                   |
     |------------|                                                     |---------------|
-fit(Spline.Cubic(), CMTYield.([0.04,0.05,0.055,0.06,0055],[1,2,3,4,5]), Fit.Bootstrap())
+fit(Spline.Cubic(), CMTYield.([0.04,0.05,0.055,0.06,0.065],[1,2,3,4,5]), Fit.Bootstrap())
                     |-------------------------------------------------|
                                               |
                                               Quotes
 ```
 
  - **Model** could be `Spline.Linear()`, `Yield.NelsonSiegelSvensson()`, `Equity.BlackScholesMerton(...)`, etc.
- - **Quote** could be `CMTYield`s, `ParYield`s, `Option.Eurocall`, etc.
+ - **Quote** could be `CMTYield`s, `ParYield`s, `Option.EuroCall`, etc.
  - **Method** could be `Fit.Loss(x->x^2)`, `Fit.Loss(x->abs(x))`, `Fit.Bootstrap()`, etc.
 
 The benefit of this versus the old Yields.jl API is:
@@ -211,9 +211,9 @@ The benefit of this versus the old Yields.jl API is:
 Model fitting can be customized:
 
 - The **loss function** (least squares, absolute difference, etc.) via the third argument to `fit`:
-  - e.g.`fit(ABDiscountLine(), quotes, FIt.Loss(x -> abs(x))`
+  - e.g.`fit(ABDiscountLine(), quotes, Fit.Loss(x -> abs(x)))`
   - the default is `Fit.Loss(x->x^2)`
-- the **optimization algorithm** by defining a method `FinanceModels.__default_optim__(m::ABDiscountLine) = OptimizationOptimJL.Newton()`
+- the **optimization algorithm** by defining a method `FinanceModels.__default_optim(m::ABDiscountLine) = OptimizationOptimJL.Newton()`
   - you may need to change the `__default_optic` to be unbounded (simply omit the `=>` and subsequent bounds)
   - The default is OptimizationMetaheuristics.ECA()
 - The **general algorithm** can be customized by creating a new method for fit: 
@@ -352,7 +352,7 @@ julia> collect(p)
 10-element Vector{NamedTuple{(:time, :payment, :outstanding), Tuple{Float64, Float64, Float64}}}:
  (time = 0.5, payment = 0.1, outstanding = 0.9)
  (time = 1.0, payment = 0.1, outstanding = 0.8)
- (time = 1.5, payment = 0.1, outstnding = 0.7000000000000001)
+ (time = 1.5, payment = 0.1, outstanding = 0.7000000000000001)
  (time = 2.0, payment = 0.1, outstanding = 0.6000000000000001)
  (time = 2.5, payment = 0.1, outstanding = 0.5000000000000001)
  (time = 3.0, payment = 0.1, outstanding = 0.40000000000000013)

--- a/posts/fitting-survival-data/index.qmd
+++ b/posts/fitting-survival-data/index.qmd
@@ -81,7 +81,9 @@ plt
 Generate 100 sample datapoints:
 
 ```{julia}
-t = rand(Weibull(fit1.param[2], fit1.param[1]), 100)
+# MortalityTables.Weibull(m, σ) has S(x) = exp(-(x/m)^(m/σ)), which in
+# Distributions.jl parameterization is Weibull(shape = m/σ, scale = m)
+t = rand(Weibull(fit1.param[1] / fit1.param[2], fit1.param[1]), 100)
 ```
 
 ### Without Censored Data"

--- a/posts/fitting-yield-curves/index.qmd
+++ b/posts/fitting-yield-curves/index.qmd
@@ -30,7 +30,7 @@ rates = Continuous.([0.01, 0.01, 0.03, 0.05, 0.07, 0.16, 0.35, 0.92, 1.40, 1.74,
 mats = [1 / 12, 2 / 12, 3 / 12, 6 / 12, 1, 2, 3, 5, 7, 10, 20, 30]
 ```
 
-The above rates and associated maturities represent prices of zero coupon bonds, which we use as the financial instrument that we will fit the curve to:
+The above rates and associated maturities represent yields of zero coupon bonds (from which the corresponding prices follow), which we use as the financial instrument that we will fit the curve to:
 
 ```{julia}
 quotes = ZCBYield.(rates, mats)

--- a/posts/getting-started-for-actuaries/index.qmd
+++ b/posts/getting-started-for-actuaries/index.qmd
@@ -73,7 +73,7 @@ The statistician Josh Day wrote [an entire blog post](https://medium.com/@josh_4
 
 Meta-programming is the essentially the ability to program the language itself, and macros are one of the tools that provide this ability. In the Paul Graham essay mentioned above, macros are an example of the competitive advantage conferred by a more powerful language.
 
-For example, when you see `@benchmark present_value(0.05, [10, 10, 10])` in Julia, the `@benchmark` is a macro (starts with `@`). It modifies the written code to wrap `present_value` in setup, timing, and summary code before returning the result of `present_value`. There is an example of this later in the article.
+For example, when you see `@benchmark present_value(0.05, [10, 10, 10])` in Julia, the `@benchmark` is a macro (starts with `@`). It modifies the written code to wrap `present_value` in setup, timing, and summary code, returning detailed timing statistics for the call. There is an example of this later in the article.
 
 Most other languages don't have macros, and it means that it's hard to 'hook into' code in a safe way. For example, benchmarking can involve a lot of boilerplate code just to setup, time, and summarize the results (such as the `timeit` library in Python)[^4].
 

--- a/posts/julia-for-actuaries/index.qmd
+++ b/posts/julia-for-actuaries/index.qmd
@@ -78,7 +78,7 @@ And then what retention means for a `Life`:
 
 ``` julia:./post/julia-for-the-future/code/ex3
 function retained(l::Life)
-  sum(retained(policy) for policy in life.policies)
+  sum(retained(policy) for policy in l.policies)
 end
 ```
 
@@ -139,7 +139,7 @@ We generate 100:
 | ``` julia                           | ``` r                              | ``` python                                  |
 | using Distributions                 | runif(100)                         | import scipy.stats as sps                   |
 |                                     | rnorm(100)                         | import numpy as np                          |
-| rand(100)                           | rbern(100, 0.5)                    |                                             |
+| rand(100)                           | rbinom(100, 1, 0.5)                |                                             |
 | rand(Normal(), 100)                 | sample(c("Preferred","Standard"),  |                                             |
 | rand(Bernoulli(0.5), 100)           | 100, replace=TRUE)                 | sps.uniform.rvs(size=100)                   |
 | rand(["Preferred","Standard"], 100) | ```                                | sps.norm.rvs(size=100)                      |
@@ -165,7 +165,7 @@ Speaking from experience, speed is not just great for production time improvemen
 
 Admittedly, most workflows don't see a 1000x speedup, but 10x to 1000x is a very common range of speed differences vs R or Python or MATLAB.
 
-Sometimes you will see less of a speed difference; R and Python have already circumvented this and written much core code in low-level languages. This is an example of what's called the "two-language" problem where the language productive to write in isn't very fast. For example, [more than half of R packages use C/C++/Fortran](https://developer.r-project.org/Blog/public/2019/03/28/use-of-c---in-packages/) and core packages in Python like Pandas, PyTorch, NumPy, SciPy, etc. do this too.
+Sometimes you will see less of a speed difference; R and Python have already circumvented this and written much core code in low-level languages. This is an example of what's called the "two-language" problem where the language productive to write in isn't very fast. For example, [about 20% of R packages include compiled C/C++/Fortran code — including many of the most-used ones](https://blog.r-project.org/2019/03/28/use-of-c-in-packages/) — and core packages in Python like Pandas, PyTorch, NumPy, SciPy, etc. do this too.
 
 Within the bounds of the optimized R/Python libraries, you can leverage this work. Extending it can be difficult: what if you have a custom retention management system running on millions of policies every night?
 

--- a/posts/life-modeling-problem/index.qmd
+++ b/posts/life-modeling-problem/index.qmd
@@ -91,7 +91,7 @@ end function
 
 Maybe more readable to the modern eye than APL, but many actuaries would still recognize what's going on with the first code example.
 
-Why did APL take off for Actuaries and not APL? I think [expressiveness](https://en.wikipedia.org/wiki/Expressive_power_%28computer_science%29) and the ability to have a language inspired by mathematical notation were attractive. It's not pleasant to write a lot of boiler-plate simply to achieve a simple objective. 
+Why did APL take off for Actuaries and not Fortran? I think [expressiveness](https://en.wikipedia.org/wiki/Expressive_power_%28computer_science%29) and the ability to have a language inspired by mathematical notation were attractive. It's not pleasant to write a lot of boiler-plate simply to achieve a simple objective. 
 
 What is boiler-plate? It's writing a lot of code supporting the main idea, but straying from a simple mathematical formulation. For example, in high performance object-oriented languages (C#/C++/Java), the idiomatic code might involve a special class. See, for example this C# code to count substrings:
 
@@ -142,23 +142,10 @@ using PrettyTables
 file = download("https://raw.githubusercontent.com/JuliaActuary/Learn/master/Benchmarks/LifeModelingProblem/benchmarks.csv")
 benchmarks = CSV.read(file, DataFrame)
 
-benchmarks.relative_mean = benchmarks.mean ./ minimum(benchmarks.mean)
-sort(benchmarks, :relative_mean)
-```
-
-To aid in visualizing results with such vast different orders of magnitude, this graph includes a physical length comparison to serve as a reference. The computation time is represented by the distance that light travels in the time for the computation to complete (comparing a nanosecond to one foot length [goes at least back to Admiral Grace Hopper](https://www.youtube.com/watch?v=9eyFDBPk4Yw)).
-
-```{julia}
-#| echo: false
-#| label: tbl-life-modeling-benchmark-blog
-#| tbl-cap: Benchmarks for the Life Modeling Problem in nanoseconds (lower times are better).
-#| 
-using CSV, DataFrames
-using PrettyTables
-file = download("https://raw.githubusercontent.com/JuliaActuary/Learn/master/Benchmarks/LifeModelingProblem/benchmarks.csv")
-benchmarks = CSV.read(file, DataFrame)
-
-benchmarks.relative_mean = benchmarks.mean ./ minimum(benchmarks.mean)
+# some languages' benchmark libraries only report a median;
+# use it where the mean is unavailable (see footnote 3)
+time_ns = coalesce.(benchmarks.mean, benchmarks.median)
+benchmarks.relative_mean = time_ns ./ minimum(time_ns)
 sort(benchmarks, :relative_mean)
 ```
 
@@ -308,7 +295,7 @@ Rust scores well here, coming second only to Julia.
 
 ##### Flexibility
 
-Rust is statically compiled (you write script, have computer run script, see results). It doesn't have a REPL or ability to be used in an interactive way (e.g. notebook environments).
+Rust is statically compiled (you write a program, compile it, and then run it to see results). It doesn't have an official REPL and interactive use (e.g. notebook environments) is uncommon, though third-party tools like [evcxr](https://github.com/evcxr/evcxr) provide a REPL and Jupyter kernel.
 
 ##### Readability
 
@@ -367,7 +354,7 @@ With [NumPy](https://numpy.org/), Python was the second fastest `Vectorized` app
 
 Python wins large points for interactive usage in the REPL, notebooks, and wide variety of environments that support running Python code. However, within the language itself I have to deduct points for the ease of inspecting/evaluating code.
 
-What I mean by that, is that if you look at the code example below, in order to test the code you have to turn it into string and then call the `timeit` function to read and parse the string. In none of the other tested languages was that sort of boiler-plate required.
+What I mean by that, is that if you look at the code example below, the idiomatic standalone `timeit` pattern turns the code into a string which the `timeit` function then reads and parses (`timeit` can also accept a callable, and IPython/Jupyter offer `%timeit`, but the string form is the common standalone-script pattern). In none of the other tested languages was that sort of boiler-plate typical.
 
 Python scores partial points for meta-programming: decorators (`@` syntax) is syntactic sugar for macro-like modifications to functions, but Python metaprogramming is [fundamentally limited](https://softwareengineering.stackexchange.com/a/253377/37060) by the language design.
 
@@ -405,7 +392,7 @@ benchmark = '''npv(q,w,P,S,r)'''
 print(timeit.timeit(stmt=benchmark,setup=setup,number = 1000000))
 ```
 
-To do non standard things like benchmarking (or The benchmarking setup with Python's `timeit` is definitely the most painful, needing to wrap the whole thing in a string. And then only get a single number result, without normalizing for the number of runs is very annoying.
+The benchmarking setup with Python's `timeit` was the most painful of the languages compared here: the common pattern wraps the code in a string, and the result is a single total time that you have to normalize by the number of runs yourself.
 
 #### Julia
 
@@ -452,7 +439,7 @@ function npv1(q,w,P,S,r)
   	return sum(ncf .* d)
 end
 
-@benchmark npv($q,$w,$P,$S,$r)
+@benchmark npv1($q,$w,$P,$S,$r)
 ```
 
 And the `Accumulator` version:
@@ -476,12 +463,6 @@ end
 ## More flexibility, more performance from Julia
 
 I wanted to go a little bit deeper and show how 1) Julia just runs fast even if your not explicitly focused on performance. But for where it *really* matters, you can go even deeper. This is a little advanced, but I think it can be useful to introduce some basics as to why some languages and approaches are going to be fundamentally slower than others.
-
-Notes:
-The accumulator approach
-vectors and allocations
-talk about stack/heap?
-pick a faster approach and explain why it's even faster.
 
 ## Colophon
 
@@ -525,14 +506,14 @@ Python 3.9.4 (default, Apr  4 2021, 17:42:23)
 
 ## Footnotes
 
-[^1] A take on [Andy and Bill's law](https://en.wikipedia.org/wiki/Andy_and_Bill%27s_law)
+[^1]: A take on [Andy and Bill's law](https://en.wikipedia.org/wiki/Andy_and_Bill%27s_law)
 
-[^2] If benchmarking memoization, it's essentially benchmarking how long it takes to perform hashing in a language. While interesting, especially in the context of [incremental computing](https://scattered-thoughts.net/writing/an-opinionated-map-of-incremental-and-streaming-systems), it's not the core issue at hand. Incremental computing libraries exist for all of the modern languages discussed here.
+[^2]: If benchmarking memoization, it's essentially benchmarking how long it takes to perform hashing in a language. While interesting, especially in the context of [incremental computing](https://scattered-thoughts.net/writing/an-opinionated-map-of-incremental-and-streaming-systems), it's not the core issue at hand. Incremental computing libraries exist for all of the modern languages discussed here.
 
-[^3] Note that not all languages have both a mean and median result in their benchmarking libraries. Mean is a better representation for a garbage-collected modern language, because sometimes the computation just takes longer than the median result. Where the mean is not available in the graph below, median is substituted.
+[^3]: Note that not all languages have both a mean and median result in their benchmarking libraries. Mean is a better representation for a garbage-collected modern language, because sometimes the computation just takes longer than the median result. Where the mean is not available in the graph below, median is substituted.
 
-[^4] Don't [prematurely optimize](https://en.wikipedia.org/wiki/Program_optimization#When_to_optimizer). But in the long run avoid, [re-writing your code in a faster language too many times!](https://www.nature.com/articles/d41586-019-02310-3)
+[^4]: Don't [prematurely optimize](https://en.wikipedia.org/wiki/Program_optimization#When_to_optimizer). But in the long run avoid, [re-writing your code in a faster language too many times!](https://www.nature.com/articles/d41586-019-02310-3)
 
-[^5]  I've seen 50+ line, irregular Excel formulas. To Nick: it probably started out as a good idea but it was a beast to understand and modify! At least with code you can look at the code with variable names and syntax highlighting! Comments, if you are lucky!
+[^5]: I've seen 50+ line, irregular Excel formulas. To Nick: it probably started out as a good idea but it was a beast to understand and modify! At least with code you can look at the code with variable names and syntax highlighting! Comments, if you are lucky!
 
-[^6] This is not legal advice, consult a lawyer for more details.
+[^6]: This is not legal advice, consult a lawyer for more details.

--- a/posts/nested-policy-projections/index.qmd
+++ b/posts/nested-policy-projections/index.qmd
@@ -146,10 +146,12 @@ function run_inner(policy, assumptions, result)
         A = innerloop_assumption(assumptions)
         p = project(policy, A; start_time=result.timestep + 1)
 
-        # calculate the reserves as the present value of the 
+        # calculate the reserves as the present value of the
         # cashflows within the inner loop projections
         # discounted at the reserve interest rate
-        reserves = -pv(A.int_reserve, [modelpoint.net_cf for modelpoint in p])
+        # (an annual rate, converted to match the monthly timesteps)
+        i_monthly = (1 + A.int_reserve)^(1 / 12) - 1
+        reserves = -pv(i_monthly, [modelpoint.net_cf for modelpoint in p])
         capital = reserves * A.capital_factor
         (; reserves, capital)
     else
@@ -177,11 +179,12 @@ function run_inner_stochastic(policy, assumptions, result)
         n = 100
 
         reserves = let
-            i = A.int_reserve
-            f = pv(i + 0.005 * randn(), [modelpoint.net_cf for modelpoint in p])
-
-            -sum(f for _ in 1:n) / n
-
+            cfs = [modelpoint.net_cf for modelpoint in p]
+            -sum(1:n) do _
+                # shock the annual rate each scenario, then convert to monthly
+                i = (1 + A.int_reserve + 0.005 * randn())^(1 / 12) - 1
+                pv(i, cfs)
+            end / n
         end
         capital = reserves * A.capital_factor
         (; reserves, capital)

--- a/posts/poisson-approximation/index.qmd
+++ b/posts/poisson-approximation/index.qmd
@@ -28,9 +28,9 @@ It's not really that simple, and arguably a bit restrictive as this analysis wil
 
 ## Approach
 
-We will use Julia and Turing.jl to simulate the posterior distribution. Our prior for the parameter \$q\$ will be \${Uniform} = Beta(1,1)\$.
+We will use Julia and Turing.jl to simulate the posterior distribution. Our prior for the parameter $q$ will be $\text{Uniform} = \text{Beta}(1,1)$.
 
-We will sample from the posterior using the No-U-Turn (NUTS) sampler, and aggregate the results of the chains over \$(trials) trials of simulated outcomes for the given \$q\$ and \$N\$.
+We will sample from the posterior using the No-U-Turn (NUTS) sampler, and aggregate the results of the chains over repeated trials of simulated outcomes for the given $q$ and $N$.
 
 This is overkill for a toy problem where we could just model the parameters themselves, but it demonstrates using Bayesian MCMC techniques in a simple, exploratory fashion.
 
@@ -50,8 +50,6 @@ using Markdown
 include(joinpath(@__DIR__, "..", "..", "assets", "themes", "cassette_futurism.jl"))
 set_theme!(cassette_futurism_theme())
 ```
-
-"""
 
 ## Define the Models
 
@@ -105,9 +103,11 @@ end
 
 ## Results
 
-The results indicate that the Poisson is a good fit when \$q\$ is small, where "small" depends on N, but in general it seems to provide a good fit in less restrictive cases than the "rule of thumb" quoted below. E.g. go ahead and use the Poisson approximation when you've got enough expsoures even if \$q\$ is well above \$0.10\$. The Poisson approximation also isn't terrible when \$N\$ is as low as 10 as long as \$q\$ is very small (e.g. \$\<0.05\$ ).
+The results indicate that the Poisson is a good fit when $q$ is small, where "small" depends on $N$, but in general it seems to provide a good fit in less restrictive cases than the "rule of thumb" quoted above. E.g. the Poisson approximation can be reasonable when you've got enough exposures even if $q$ is above $0.10$. The Poisson approximation also isn't terrible when $N$ is as low as 10 as long as $q$ is very small (e.g. $<0.05$).
 
-The fit remains poor when \$q \>\> 0.5\$ and when \$N\$ is small.
+The fit remains poor when $q$ is well above $0.5$ and when $N$ is small.
+
+One caveat: increasing $N$ improves the *location* of the Poisson-based posterior but not its relative *width*. Because the Poisson likelihood lacks the $(1-q)$ variance-shrinking term of the Binomial, its posterior standard deviation is inflated by a factor of roughly $1/\sqrt{1-q}$ regardless of $N$ (about +15% at $q=0.25$ and +41% at $q=0.5$), so posterior intervals from the Poisson model are systematically wider at moderate-to-high $q$ even when the point estimate is accurate.
 
 ### Visualization
 

--- a/posts/policy-diffeq/index.qmd
+++ b/posts/policy-diffeq/index.qmd
@@ -50,7 +50,7 @@ In the code below, this translates to:
 
 - `u` is the *state* of the system. We  will track three variables to represent the `state`:
    - `state[1]` is the account value
-   - `state[2]` is the premium paid
+   - `state[2]` is the premium paid at that timestep
    - `state[3]` is the policy duration
 - `p` are the parameters of the system.
 - `t` is the time, which will represent days since policy issuance
@@ -91,7 +91,7 @@ function policy_projection(state, p, t)
         end
 
         # daily events
-        int(av) = av * ((1 + p.int_rate)^(1 / 360) - 1.0)
+        int(av) = av * ((1 + p.int_rate)^(1 / 365) - 1.0)
 
 
 
@@ -127,7 +127,7 @@ params(prem, int) = (
 
 ## Runing the system
 
-This results in the following plot. The tracked output variables u1 and u2 represent the two vars that we tracked above: account value and cumulative premium.
+This results in the following plot of the tracked account value (`state[1]`):
 
 ```{julia}
 begin
@@ -160,7 +160,7 @@ end
 
 An excellent way to understand the behavior of a model is to [move up the ladder of abstraction](http://worrydream.com/LadderOfAbstraction/). Below, we will see what happens to the projection at varying levels of credit rates and annual premiums.
 
-md"The full range of simulated outcomes can take a couple of minutes to run:
+The full range of simulated outcomes can take a couple of minutes to run:
 
 ```{julia}
 begin
@@ -173,7 +173,8 @@ begin
         proj = solve(prob, FunctionMap())
         end_av = proj[end][1]
         if end_av == 0.0
-            lapse_time = findfirst(isequal(0.0), proj[1, 2:end])
+            # +1 because the search starts at the 2nd column of `proj`
+            lapse_time = findfirst(isequal(0.0), proj[1, 2:end]) + 1
         else
             lapse_time = length(proj)
         end

--- a/posts/quantlib-comparison/index.qmd
+++ b/posts/quantlib-comparison/index.qmd
@@ -28,7 +28,7 @@ For the workflows it covers, [JuliaActuary](https://juliaactuary.org)'s answer i
 
 ## The cashflow vector
 
-A 5-year, 4% semi-annual-coupon bond at a flat 3% continuously-compounded yield. Once the vector exists, price and duration are one function call each.
+A 5-year, 4% semi-annual-coupon bond priced against a simple upward-sloping zero curve (a flat 3% continuously-compounded yield appears later for the convention comparisons). Once the vector exists, price and duration are one function call each.
 
 ```{julia}
 using FinanceCore
@@ -65,6 +65,7 @@ QuantLib's setup is longer — a `Schedule`, a `FixedRateBond`, a `FlatForward` 
 import QuantLib as ql
 
 settle    = ql.Date(1, 1, 2026)
+ql.Settings.instance().evaluationDate = settle
 maturity  = ql.Date(1, 1, 2031)
 day_count = ql.Thirty360(ql.Thirty360.BondBasis)
 
@@ -80,12 +81,18 @@ curve = ql.ZeroCurve(pillar_dates, zeros, day_count, ql.NullCalendar(),
 bond.setPricingEngine(ql.DiscountingBondEngine(ql.YieldTermStructureHandle(curve)))
 
 print(bond.NPV())  # → 103.6781792217
+
+ytm = bond.bondYield(day_count, ql.Continuous, ql.NoFrequency)   # ≈ 0.0317283
+ir  = ql.InterestRate(ytm, day_count, ql.Continuous, ql.NoFrequency)
+print(ql.BondFunctions.duration(bond, ir, ql.Duration.Modified))  # → 4.5902412191
 ```
 
-| metric            | FinanceModels / ActuaryUtilities | QuantLib (Python) | diff |
-|-------------------|----------------------------------|-------------------|------|
-| Price             | 103.6781792217                   | 103.6781792217    | 0.00 |
-| Modified duration | 4.5873235505                     | 4.5873235505      | 0.00 |
+| metric            | FinanceModels / ActuaryUtilities | QuantLib (Python) | diff    |
+|-------------------|----------------------------------|-------------------|---------|
+| Price             | 103.6781792217                   | 103.6781792217    | 0.00    |
+| Modified duration | 4.5873235505                     | 4.5902412191      | 2.9e-03 |
+
+The prices agree to the last printed digit. The durations differ slightly because the two are answering slightly different questions: `duration(Modified(), curve, cfs)` differentiates the price with respect to a *parallel shift of the term-structured curve*, while QL's native `BondFunctions.duration` works from a single flat yield-to-maturity (the bond's continuously-compounded ytm of ≈3.17%). Reproducing the curve-based number in QL means bumping every pillar of the `ZeroCurve` and repricing by hand — which is exactly what the key-rate-duration section below does.
 
 The interesting part is what the same `cfs` is about to do without writing any new code.
 
@@ -142,6 +149,7 @@ QuantLib has a native `BondFunctions.convexity`:
 
 ```python
 # Python — QuantLib
+import math
 y_ann = math.exp(0.03) - 1                  # annual-effective equiv. of 3% cont.
 ir    = ql.InterestRate(y_ann, day_count, ql.Compounded, ql.Annual)
 convex_quantlib = ql.BondFunctions.convexity(bond, ir)   # → 25.2585956899
@@ -149,13 +157,13 @@ convex_quantlib = ql.BondFunctions.convexity(bond, ir)   # → 25.2585956899
 
 They report different numbers — exactly `(1+y)²` apart — because they use different conventions:
 
-| metric                                         |    value    |
-|------------------------------------------------|------------:|
-| `ActuaryUtilities.convexity`     ("Macaulay")  |  26.8205000 |
-| `QuantLib.BondFunctions.convexity` ("modified")|  25.2585957 |
-| QL × `(1 + y_ann)²`                            |  26.8205000 |
+| metric                                                     |    value    |
+|------------------------------------------------------------|------------:|
+| `ActuaryUtilities.convexity`     (annual-effective shock)  |  26.8205000 |
+| `QuantLib.BondFunctions.convexity` ("modified")            |  25.2585957 |
+| QL × `(1 + y_ann)²`                                        |  26.8205000 |
 
-QuantLib normalizes by `(1+y)²` — the extra chain-rule factor that drops out when you differentiate against the *periodic* yield. That's "modified convexity" in the discrete-compounding sense. ActuaryUtilities reports the unnormalized second moment of cashflow times — the convexity that Bloomberg and most actuarial references show. Neither is wrong; both show up in industry. The conversion is a single multiplication.
+QuantLib normalizes by `(1+y)²` — the extra chain-rule factor from differentiating against the *periodic* yield. That's "modified convexity" in the discrete-compounding sense, and it's the figure most market data terminals display. ActuaryUtilities reports the unnormalized second derivative with respect to an annual-effective shock — `Σ t(t+1)·w` in discounted-cashflow-weight terms, i.e. the same quantity before the `(1+y)⁻²` normalization. Neither is wrong; both show up in industry. The conversion is a single multiplication.
 
 ::: {.callout-note collapse="true"}
 ## Under the hood: how `convexity` works (and how to write your own convention)
@@ -170,7 +178,7 @@ function convexity(yield, cfs)
 end
 ```
 
-The shock convention is set by how `yield + Δ` is defined for the yield type. For `Yield.Constant{Continuous}`, `+` uses `log1p` semantics so `Δ` is interpreted as a *periodic*-rate shock — which gives Macaulay-style `t·(t+1)` convexity. For a continuous-rate convexity instead, write the AD call directly against your own parameterization:
+The shock convention is set by how `yield + Δ` is defined for the yield type. For `Yield.Constant{Continuous}`, `+` uses `log1p` semantics so `Δ` is interpreted as a *periodic*-rate shock — which gives the annual-effective-shock `t·(t+1)` convexity. For a continuous-rate convexity instead, write the AD call directly against your own parameterization:
 
 ```{julia}
 using ForwardDiff
@@ -249,7 +257,7 @@ println("durations by pillar    = ", round.(result.durations; digits=6))
     sum(result.convexities))
 ```
 
-Each entry of `result.durations` is the bond's sensitivity at the corresponding knot in `tenors` — the same Ho-1992 triangular-hat decomposition as the previous section, computed analytically in a single forward pass instead of pillar-by-pillar finite differences. The full convexity *matrix* (6×6 here) gives cross-pillar second-order effects: `result.convexities[i, j]` is `∂²price / ∂z_i ∂z_j`; summed, that matrix gives the *continuous-shock* convexity, which sits exactly one Modified duration below the Macaulay `convexity()` reported earlier — the compounding-convention split from the convexity section resurfacing, not a discrepancy. There is no "sensitivity mode" anywhere in the library; `ZeroRateCurve` and `pv` are ordinary functions that happen to be generic on numeric types, and `sensitivities` bundles the value, gradient, and Hessian.
+Each entry of `result.durations` is the bond's sensitivity at the corresponding knot in `tenors` — the same Ho-1992 triangular-hat decomposition as the previous section, computed analytically in a single forward pass instead of pillar-by-pillar finite differences. The full convexity *matrix* (6×6 here) gives cross-pillar second-order effects: `result.convexities[i, j]` is `∂²price / ∂z_i ∂z_j`; summed, that matrix gives the *continuous-shock* convexity under `zrc`. Recall from the convexity section that the continuous-shock and annual-effective-shock conventions differ by one Modified duration — an identity that is exact when both are computed against the same discounting model (the earlier `convexity()` figure used the flat 3% model, so the relationship to that specific number is approximate). The compounding-convention split resurfacing, not a discrepancy. There is no "sensitivity mode" anywhere in the library; `ZeroRateCurve` and `pv` are ordinary functions that happen to be generic on numeric types, and `sensitivities` bundles the value, gradient, and Hessian.
 
 Switch the reporting unit without touching the inputs: a `DV01()` marker turns the same call into the per-pillar *dollar value of a basis point*, summing to the position-level DV01:
 
@@ -268,7 +276,7 @@ cfs_big = collect(FinanceModels.Bond.Fixed(big"0.04", Periodic(2), 5))
 duration(Modified(), yield_big, cfs_big)
 ```
 
-With QuantLib the entire library is `double`; raising precision is a library fork.
+With QuantLib the entire library is compiled against a single `Real` typedef (`double` in every stock distribution); changing precision means recompiling the C++ library and its bindings, not swapping a type at the call site.
 
 The composability does have limits worth naming. `ForwardDiff` walks through whatever Julia code you write *as long as* the code stays in generic-numeric territory — Float64 type pins, in-place mutation, and FFI calls into non-Dual-aware solvers (some configurations of `Optim.LBFGS`, certain root-finders) break the chain. FinanceModels' own interfaces are written to be AD-friendly throughout; the caveats are about user code that reaches outside the library.
 
@@ -371,7 +379,7 @@ hw_pvs = [FinanceCore.present_value(p, cfs_static) for p in paths]
     mc_standard_error=std(hw_pvs) / sqrt(length(hw_pvs)))
 ```
 
-Under a flat calibrating curve and σ = 1% the MC mean sits a few cents above the deterministic, with an MC standard error of comparable size — read: the gap is *consistent with* a small Jensen's-inequality correction from rate volatility, but at this σ the signal isn't large versus the MC noise. A realistic 2026 calibration would put σ in the 80–120bp range, where the correction is comfortably outside the SE. The composition itself is the takeaway: `simulate` produces yield-curve scenarios, `present_value` prices contracts against them, and the existing valuation machinery handles the rest. Closed-form `present_value` is also available under the Gaussian models for ZCB calls and puts, caps, floors, and Jamshidian-decomposed European swaptions.
+The MC mean sits within a couple of standard errors of the deterministic PV — and that's the expected result, not a shortfall of the simulation. Hull-White's θ(t) is fitted to the calibrating curve, so by construction the expectation of the pathwise discount factors reproduces the curve's discount factors; for *fixed* cashflows the MC mean is an unbiased estimator of the deterministic PV at any σ. The residual gap is Monte-Carlo noise plus the Euler scheme's O(Δt) discretization bias, and it shrinks with more scenarios and finer timesteps. (Volatility-driven "convexity corrections" arise for rate-*dependent* payoffs — a floating leg, an option — not for fixed cashflows discounted along each path.) The composition itself is the takeaway: `simulate` produces yield-curve scenarios, `present_value` prices contracts against them, and the existing valuation machinery handles the rest. Closed-form `present_value` is also available under the Gaussian models for ZCB calls and puts, caps, floors, and Jamshidian-decomposed European swaptions.
 
 The payoff of scenarios *being* yield curves shows up when you differentiate. `simulate` threads `ForwardDiff.Dual` types, so the AD walks straight *through* the Monte Carlo PV — no bumping, no separate Greek path. ActuaryUtilities 5.8 ships that as a first-class call: hand `sensitivities` a `KeyRates(tenors)` marker and a short-rate model, and it returns Monte-Carlo key-rate durations (plus a convexity matrix, and a `DV01()` variant) from one AD pass over the scenario set:
 
@@ -407,7 +415,7 @@ dPdr0_vas = ForwardDiff.derivative(pv_mc_vasicek_r0, r0_base)
 
 Same common-random-numbers seed across the value and the gradient, so the derivative is the pathwise sensitivity rather than a bumped finite difference — and like any MC estimate it carries a standard error you'd report alongside it. Two kinds of stochastic-model sensitivity flow through `ForwardDiff` today: against the calibrating *curve* (the shipped `sensitivities(KeyRates(…), hw, …)` call above) and against an *initial rate* (the scalar derivative here). Differentiating against the SDE *coefficients* — mean reversion `a`, vol `σ` — still trips a `Float64` type-pin inside `simulate`'s path buffers; it's a narrow FM fix, but not yet shipped.
 
-QL fundamentally can't do any of this through Python, because the FFI boundary breaks the AD chain. For MC-based calibration objectives with exact gradients, or pathwise sensitivities under a short-rate model, JA is ahead of QL by capability, not by speed.
+Stock QuantLib-Python can't do any of this, because the FFI boundary breaks the AD chain. (Specialized AAD builds of QuantLib exist — e.g. the XAD-based QuantLib-Risks project, which embeds the AD inside the C++ layer and exposes it to Python — but they are separate distributions, not the library most users install.) For MC-based calibration objectives with exact gradients, or pathwise sensitivities under a short-rate model, JA is ahead of QL by capability, not by speed.
 
 What FM lacks is the *lattice* layer: there's no trinomial-tree engine for early-exercise payoffs, no built-in Longstaff-Schwartz for American Monte Carlo, no multi-factor models like G2++ or LMM, and no calibrator against a swaption-cube vol surface. For a Bermudan callable bond valued under a calibrated short-rate model with market vols, QL's tree engine is still the right tool. The QL-only territory is more precisely *lattice-based early-exercise valuation under stochastic rates*, rather than stochastic rates in general, which JA handles directly.
 
@@ -440,12 +448,14 @@ QuantLib-Python via `timeit`:
 
 | Workload — JA call / QL call                                                            | FinanceModels (Julia) | QuantLib (Python)  | factor |
 |------------------------------------------------------------------------------------------|-----------------------|--------------------|--------|
-| Bond price — `FinanceCore.pv` / `bond.NPV()`                                             | ~25 ns                | ~235 ns            | ~9×    |
+| Bond price — `FinanceCore.pv` / `bond.NPV()` (cached / forced reprice)                   | ~25 ns                | ~235 ns / ~1.2 μs  | ~9× / ~50× |
 | Modified duration — `duration(Modified(), …)` / `BondFunctions.duration`                 | ~260 ns (AD)          | ~1.25 μs           | ~5×    |
 | Convexity — `convexity` / `BondFunctions.convexity`                                      | ~300 ns (nested AD)   | ~1.25 μs           | ~4×    |
 | 30-pillar KRD — `duration(KeyRates(tenors), zrc, cfs)` / per-pillar `ZeroCurve` bumps          | ~10 μs (single AD pass)| ~1170 μs          | ~120×  |
 
-Two things drive the gap. First, **the Python boundary, not the C++ math**: every QL call dispatched from Python costs ~200–300 ns of object marshaling regardless of what's on the other side. For single-instrument metrics — price, duration, convexity — the actual C++ work is fast enough that the boundary cost dominates, which is why all three rows land in the same 4–9× neighborhood. Duration and convexity both clock in at ~1.25 μs because they're the same shape from Python's perspective: one bond, one `InterestRate`, one C++ function call, one returned scalar.
+One caveat on the price row: QL `Instrument`s are `LazyObject`s, so after the first call `bond.NPV()` returns a cached value until an observable changes — the ~235 ns figure is SWIG marshaling plus a cache hit, not repricing. Forcing a recalculation (`bond.recalculate()` before the `NPV()` call, or bumping a `SimpleQuote` feeding the curve) costs ~1.2 μs, in line with the duration and convexity rows, which do recompute on every call.
+
+Two things drive the gap. First, **the Python boundary, not the C++ math**: every QL call dispatched from Python costs ~200–300 ns of object marshaling regardless of what's on the other side. For single-instrument metrics — price, duration, convexity — the C++ work per call is small enough that the boundary cost is a large share of the total, which is why the recomputing rows all land in the same ~1.2 μs neighborhood: one bond, one `InterestRate`, one C++ function call, one returned scalar.
 
 ::: {.callout-note collapse="true"}
 ## Is the ~200–300 ns Python boundary fundamental, or just SWIG?
@@ -525,20 +535,28 @@ bond.setPricingEngine(ql.DiscountingBondEngine(ql.YieldTermStructureHandle(flat)
 y_ann = math.exp(0.03) - 1
 ir    = ql.InterestRate(y_ann, day_count, ql.Compounded, ql.Annual)
 
+# NB: Instruments are LazyObjects — after the first call NPV() is cached until an
+# observable changes, so the first line times marshaling + a cache hit. The
+# second forces a full reprice on every iteration.
 timeit.timeit(lambda: bond.NPV(),                                                number=10_000)
+timeit.timeit(lambda: (bond.recalculate(), bond.NPV()),                          number=10_000)
 timeit.timeit(lambda: ql.BondFunctions.duration(bond, ir, ql.Duration.Modified), number=10_000)
 timeit.timeit(lambda: ql.BondFunctions.convexity(bond, ir),                      number=10_000)
 
-# 30-pillar KRD setup
+base_price = bond.NPV()
+
+# 30-pillar KRD setup. The t = 0 anchor pillar is required: without it the
+# ZeroCurve's reference date becomes the 1y pillar and the bond's first coupon
+# sits at negative time, which throws.
 pillars         = list(range(1, 31))
-pillar_dates_30 = [settle + ql.Period(y, ql.Years) for y in pillars]
-flat_zeros_30   = [0.03] * len(pillars)
+pillar_dates_30 = [settle + ql.Period(y, ql.Years) for y in [0] + pillars]
+flat_zeros_30   = [0.03] * (len(pillars) + 1)
 shift           = 1e-3
 
 # Per-pillar ZeroCurve bump-and-rebuild
 def krd_zerocurve():
     out = []
-    for i in range(len(pillars)):
+    for i in range(1, len(pillars) + 1):   # bump the 1y..30y pillars, not the anchor
         up = flat_zeros_30[:];  up[i] += shift
         dn = flat_zeros_30[:];  dn[i] -= shift
         zc_up = ql.ZeroCurve(pillar_dates_30, up, day_count, ql.NullCalendar(),
@@ -549,7 +567,7 @@ def krd_zerocurve():
         p_up = bond.NPV()
         bond.setPricingEngine(ql.DiscountingBondEngine(ql.YieldTermStructureHandle(zc_dn)))
         p_dn = bond.NPV()
-        out.append((p_dn - p_up) / (2 * shift * 100))
+        out.append((p_dn - p_up) / (2 * shift * base_price))
     bond.setPricingEngine(ql.DiscountingBondEngine(ql.YieldTermStructureHandle(flat)))
     return out
 
@@ -567,7 +585,7 @@ The two libraries aren't really competing for the same job. They're optimized fo
 
 ---
 
-The `cfs` defined at the top of this post threaded through every example: price, Macaulay and Modified duration, convexity, ten KRDs, a 30-pillar KRD benchmark, the second-order sensitivity through a calibrated zero curve, the prepayment-sensitive mortgage pool with refi response, the Hull-White Monte Carlo. The library never needed a sensitivity-specific API or an AD-aware override; generic numeric types flowed through ordinary functions, and `ForwardDiff` extracted whatever derivative each step needed.
+The `cfs` defined at the top of this post threaded through most of the examples: price, Modified duration, convexity, ten KRDs, a 30-pillar KRD benchmark, the second-order sensitivity through a calibrated zero curve. Its mortgage-pool sibling carried the prepayment-sensitive refi example and the Hull-White Monte Carlo — same `Cashflow` vocabulary, same functions. The library never needed a sensitivity-specific API or an AD-aware override; generic numeric types flowed through ordinary functions, and `ForwardDiff` extracted whatever derivative each step needed.
 
 That's the part that's hard to retrofit into a framework written before automatic differentiation became cheap.
 

--- a/posts/stochastic-mortality/index.qmd
+++ b/posts/stochastic-mortality/index.qmd
@@ -26,7 +26,7 @@ set_theme!(cassette_futurism_theme())
 
 Define a datatype. Not strictly necessary, but will make extending the program with more functions easier.
 
-Type annotations are optional, but providing them is able to coerce the values to be all plain bits (i.e. simple, non-referenced values like arrays are) when the type is constructed. This makes the whole data be stored in the stack and is an example of data-oriented design. It's much slower without the type annotations (~0.5 million policies per second, ~50x slower).
+Type annotations are optional, but providing them is able to coerce the values to be all plain bits (i.e. simple, non-referenced values like arrays are) when the type is constructed. This lets the policies be stored inline and contiguously in the array (no pointer chasing) and is an example of data-oriented design. It's much slower without the type annotations (~0.5 million policies per second, roughly 90x slower than the ~45 million per second benchmarked below).
 
 ```{julia}
 @enum Sex Female = 1 Male = 2
@@ -109,8 +109,8 @@ function pol_project!(benefits, lives, policy, params)
 
     # inbounds turns off bounds-checking, which makes hot loops faster — write
     # the loop without it first to ensure you don't have an out-of-bounds bug.
-    @inbounds for t in 1:min(params.proj_length, ω - start_age)
-        q = qs[start_age + t]            # current mortality
+    @inbounds for t in 1:min(params.proj_length, ω - start_age + 1)
+        q = qs[start_age + t - 1]        # mortality for the current projection year
         rand() < q && return              # death — stop incrementing this life
 
         # otherwise: pay benefit, add a life, grow the benefit by COLA for next year


### PR DESCRIPTION
A page-by-page correctness review of every source page (8 top-level pages + 26 posts), fixing errors in code, math, and exposition. Only source files are touched; `_site/` needs a manual `quarto render` to pick these up.

## Real bugs in code

- **bayesian-claims-demo**: `inforce_years` is a scalar, so `tbl.select[issue_age][issue_age .+ inforce_years .- 1]` indexed a *single* rate — every simulated year used the terminal attained age's mortality. Now indexes per duration. Also: `num_chains = 4` was defined but a single chain sampled; the model-4 posterior plot hard-coded `c = 0` despite the model sampling `c ~ Beta(4,18)`.
- **nested-policy-projections**: the "stochastic" inner loop computed `f = pv(i + 0.005*randn(), …)` once and then averaged the same scalar 100 times — one draw, not a distribution. The 2% *annual* reserve rate was also applied per *month* (timesteps are monthly). Both fixed.
- **autodiff_ALM**: the per-pillar KRD constraint *subtracted* the liability gradient while the budget and total-duration constraints add it (liability values/gradients are already signed) — the hedge only looked right because the wide bounds and the correctly-signed total-duration constraint did the work. Also the `:duration` bounds were defined but never used (the `:krd` bounds were reused).
- **stochastic-mortality**: first projection year applied next year's mortality (`qs[start_age + t]`) against the current year's benefit — off by one.
- **fitting-survival-data**: sampled `Weibull(σ̂, m̂)` from a fit whose Distributions.jl equivalent is `Weibull(m̂/σ̂, m̂)` (only numerically masked because σ̂² ≈ m̂ for this dataset).
- **exposures-example / packages.qmd**: exposure fraction ignored that ExperienceAnalysis returns an *inclusive* `to` date (every period one day short) and used Actual/360 (full policy year ⇒ 1.011 exposure) against prose that says 30/360.
- **policy-diffeq**: 1/360 interest exponent with calendar-day stepping (8% input → 8.12% effective), lapse-time off-by-one from slicing at column 2.
- **life-modeling-problem**: the benchmark table computed `mean ./ minimum(mean)` over a column with `missing`s ⇒ the whole relative column rendered `missing`; the "Vectorized" benchmark called undefined `npv` instead of `npv1`; an entire table block was duplicated verbatim.
- **index.qmd**: Life Contingencies carousel snippet used `lc` without defining it (and unexported `V`).
- **packages.qmd**: `m_rate`/`m_spread` undefined (bound as `model_*`); `discount(a+b,0,3) ≈ discount(0.01+0.03,3) # true` is **false** (verified by execution — model composition is multiplicative, now shown as such); nonexistent 3-arg `zero(curve,time,Frequency)`; `0055` parses as integer 55 (a 5,500% yield); `CoxIngersolRoss` misspelled; an invisible U+2800 character in a code line that errors on copy-paste.
- **finance-models-announcement**: broken `Transducers` import (`using M: names` doesn't bind `M`), same `0055` literal, `FIt.Loss` + missing paren, `__default_optim__` (the real hook is `__default_optim`), `Option.Eurocall` capitalization, 15/365 = 0.041 not 0.057, and a hand-mangled `outstnding` field in claimed REPL output.
- **julia-for-actuaries**: `retained(l::Life)` referenced the global `life` instead of its argument; `rbern` isn't base R.

## QuantLib comparison (claims re-verified by running QuantLib locally)

- The headline table showed QL modified duration matching AU to 10 digits with "diff 0.00" — no shown QL call produces that number. Native `BondFunctions.duration` gives **4.5902412191** (reproduced locally); the table now shows the real figure and explains the curve-shift vs flat-ytm convention difference.
- The first pricing snippet omitted `evaluationDate`, so its printed NPV only reproduces if run on Jan 1, 2026.
- The "~235 ns bond price" benchmark row times a `LazyObject` **cache hit**, not pricing (forced reprice: ~1.2 μs, reproduced locally). Row and discussion corrected.
- The KRD benchmark snippet **throws** as written ("negative time (-0.5)") because the t=0 anchor pillar is missing, and normalized by hard-coded 100 instead of the price. Fixed and verified to run (Σ KRD recovers the modified duration).
- The Hull-White MC paragraph attributed the deterministic-vs-MC gap to a Jensen's-inequality volatility correction; with θ(t) fitted to the curve the MC mean is unbiased for fixed cashflows at any σ — rewritten as MC noise + O(Δt) discretization bias.
- Convexity table mislabeled Σt(t+1)w as the "second moment"/"Macaulay" convexity (self-contradicting the later continuous-shock section); softened over-broad claims ("raising precision is a library fork", "QL fundamentally can't do AD through Python" — QuantLib-Risks exists).

## Statistical / conceptual exposition

- Limited-fluctuation credibility criterion stated as an absolute margin; it's *relative* to the true rate.
- Poisson-approximation post now notes the posterior-width inflation of ≈1/√(1−q) that does **not** shrink with N (location converges; interval width doesn't).
- Maximum-entropy distribution conditions corrected (Exponential: positive support + fixed mean; Normal: fixed mean and variance; Uniform: bounded support).
- Dynamic-vs-static duration prose in autodiff_ALM said dynamic sensitivity is *higher*; the code's own output (and the surrender-option economics) show it's lower.
- Misc: prior/posterior word swap, "APL and not APL" → Fortran, ~50x vs the actual 90x speedup arithmetic, BSM Python relative-mean computed against the wrong denominator, 701 cashflows ≠ "60 years monthly", R native-code statistic (≈20% of packages, not "more than half"), Rust does have third-party REPL/notebook support, `timeit` doesn't require strings.

## Housekeeping with reader-visible impact

- Un-evaluated Pluto-era `$(...)` interpolations and stray `"""`/`md"` artifacts rendering as literal text (4 posts); broken footnote syntax (`[^1]` without colon) in two pages; leftover draft outline notes in life-modeling-problem; broken internal links/anchors (index, benchmarks, both academy posts, exposures-example); Makie theme's `tickalign = 1.0` places ticks *inward* while the docstring and comments say "outward — draftsman style" (0 = out in Makie), and the `Figure = (...)` theme block is silently ignored (`figure_padding` moved to top level where Makie reads it).

Every finding was verified against the source (and where numeric, by execution — FinanceModels/QuantLib results reproduced locally) before editing. The site will need `quarto render` re-run by a maintainer to regenerate `_site/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)